### PR TITLE
Adding securityfs mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,13 @@ VERSION ?= $(shell git describe --tags --dirty)
 DOCKER_BUILDX_FLAGS ?=
 #DOCKER_PLATFORMS ?= linux/amd64,linux/arm64
 DOCKER_PLATFORMS ?= linux/amd64
-DOCKER_TAG ?= ghcr.io/githedgehog/k8s-tpm-device-plugin:$(VERSION)
+DOCKER_TAG ?= ghcr.io/keylime/k8s-tpm-device-plugin:$(VERSION)
 
 # helm chart version must be semver 2 compliant
 HELM_CHART_VERSION ?= $(shell echo $(VERSION) | sed 's/^v//')
 HELM_CHART_DIR := $(BUILD_DIR)/helm/k8s-tpm-device-plugin
 HELM_CHART_FILES := $(shell find $(HELM_CHART_DIR) -type f)
-HELM_CHART_REPO ?= ghcr.io/githedgehog/k8s-tpm-device-plugin/helm-charts
+HELM_CHART_REPO ?= ghcr.io/keylime/k8s-tpm-device-plugin/helm-charts
 
 ##@ General
 
@@ -105,7 +105,8 @@ test-cover: ## Runs golang unit tests and generates code coverage information
 ##@ Build
 
 .PHONY: docker-build
-docker-build: ## Builds the application in a docker container and creates a docker image
+docker-build:
+## Builds the application in a docker container and creates a docker image
 	docker buildx build \
 		-f $(MKFILE_DIR)/build/docker/k8s-tpm-device-plugin/Dockerfile \
 		-t $(DOCKER_TAG) \

--- a/cmd/k8s-tpm-device-plugin/main.go
+++ b/cmd/k8s-tpm-device-plugin/main.go
@@ -108,6 +108,18 @@ func main() {
 				Value:   false,
 				EnvVars: []string{"PASS_TPM2TOOLS_TCTI_ENV_VAR"},
 			},
+			&cli.StringFlag{
+				Name:    "mblog_mountpoint",
+				Usage:   "container path to mount the binary boot log onto",
+				Value:   "/", // default is just the root file system
+				EnvVars: []string{"MBLOG_MOUNTPOINT"},
+			},
+			&cli.StringFlag{
+				Name:    "imalog_mountpoint",
+				Usage:   "container path to mount the IMA log onto",
+				Value:   "/", // default is just the root file system
+				EnvVars: []string{"IMALOG_MOUNTPOINT"},
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			// initialize logger
@@ -164,11 +176,18 @@ func run(cliCtx *cli.Context, l *zap.Logger) error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
-	p1, err := tpmrm.New(l, cliCtx.Uint("num-tpmrm-devices"), cliCtx.Bool("pass-tpm2tools-tcti-env-var"))
+	p1, err := tpmrm.New(l,
+	                     cliCtx.Uint("num-tpmrm-devices"),
+			     cliCtx.Bool("pass-tpm2tools-tcti-env-var"),
+			     cliCtx.String("mblog-mountpoint"),
+			     cliCtx.String("imalog-mountpoint"))
 	if err != nil {
 		return fmt.Errorf("tpmrm: device plugin create: %w", err)
 	}
-	p2, err := tpm.New(l, cliCtx.Bool("pass-tpm2tools-tcti-env-var"))
+	p2, err := tpm.New(l,
+	                   cliCtx.Bool("pass-tpm2tools-tcti-env-var"),
+			   cliCtx.String("mblog-mountpoint"),
+			   cliCtx.String("imalog-mountpoint"))
 	if err != nil {
 		return fmt.Errorf("tpm: device plugin create: %w", err)
 	}


### PR DESCRIPTION
Allow the device plugin to also create mounts for the IMA and MBA logs.
The device plugin also gets two new environment variables to control the mount points. 
Default mount point is `/` for both logs.